### PR TITLE
[5.4] Add a name to home route

### DIFF
--- a/src/Illuminate/Auth/Console/stubs/make/routes.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/routes.stub
@@ -1,4 +1,4 @@
 
 Auth::routes();
 
-Route::get('/home', 'HomeController@index');
+Route::get('/home', 'HomeController@index')->name('home');


### PR DESCRIPTION
Since redirect()->home() uses named route, maybe it's more preferable to get this from the box, like others generated routes.